### PR TITLE
Pass `strict` arg to nested `MessageField`s

### DIFF
--- a/protox/fields.py
+++ b/protox/fields.py
@@ -683,10 +683,10 @@ class MessageField(Field):
         encoded_message = value.to_bytes()
         return encode_bytes(encoded_message)
 
-    def decode(self, stream: IO):
+    def decode(self, stream: IO, *, strict=True):
         length = decode_varint(stream)
         message_stream = io.BytesIO(stream.read(length))
-        return self.of_type.from_stream(message_stream)
+        return self.of_type.from_stream(message_stream, strict=strict)
 
     def validate_value(self, value):
         if not isinstance(value, self.of_type):

--- a/protox/message.py
+++ b/protox/message.py
@@ -338,6 +338,8 @@ class Message(metaclass=MessageMeta):
                 elif isinstance(field, MapField):
                     key, value = field.decode(stream)
                     message_fields.setdefault(field.name, {})[key] = value
+                elif isinstance(field, MessageField):
+                    message_fields[field.name] = field.decode(stream, strict=strict)
                 else:
                     message_fields[field.name] = field.decode(stream)
             else:


### PR DESCRIPTION
Now `strict` arg affects the entire message, not only the top level.