### PR TITLE
Fix `NameError` in generated files without messages

### DIFF
--- a/protox/plugin/protobuf_code_generator.py
+++ b/protox/plugin/protobuf_code_generator.py
@@ -319,8 +319,7 @@ class ProtobufCodeGenerator:
         if self._uses_enums or self._uses_typing:
             nl()
 
-        if self.has_messages():
-            w('import protox\n')
+        w('import protox\n')
 
         for file in self._import_requests.values():
             if self._index.base_package:

--- a/run_code_gen_tests.sh
+++ b/run_code_gen_tests.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
+set -e
 
 tmp_dir="$(mktemp -d -t proto-XXXXXXXXXX)"
 
-python3.8 -m pip install .
+python3.8 -m pip install . grpclib protobuf grpcio-tools
 echo '+ Protox installed'
 
-protoc \
+python3.8 -m grpc_tools.protoc \
   --proto_path=tests/code_gen_tests \
   --protox_out=$tmp_dir \
   --protox_opt="--with-dependencies" \

--- a/tests/code_gen_tests/enums_only.proto
+++ b/tests/code_gen_tests/enums_only.proto
@@ -1,0 +1,7 @@
+syntax = "proto2";
+
+enum Shape {
+    ROUND = 1;
+    SQUARE = 2;
+    TRIANGLE = 3;
+}


### PR DESCRIPTION
If such files still need `FILE_DESCRIPTOR` then it has to fixed in another line.