### PR TITLE
Add message repr

### DIFF
--- a/protox/message.py
+++ b/protox/message.py
@@ -463,7 +463,7 @@ class Message(metaclass=MessageMeta):
 
         return not self == other
 
-    def __str__(self):
+    def __repr__(self):
         return self._format()
 
     _format_indent = ' ' * 4


### PR DESCRIPTION
Do you prefer `eval()`-able result instead?